### PR TITLE
The issues in date_from_string and datetime_from_string functions.

### DIFF
--- a/docuware/utils.py
+++ b/docuware/utils.py
@@ -11,12 +11,22 @@ DATE_PATTERN = re.compile(r"/Date\((\d+)\)/")
 
 
 def datetime_from_string(value:str, auto_date:bool=False) -> Union[date,datetime,None]:
+    """
+    Dates earlier than 1970 and later than 2038 are breaks the code
+    and not just for the document which has inccorect date entry but also
+    all remaining documents in that search dialog. By returning None we
+    easly identify those currepted documents and inform the owner so they
+    can be fixed.
+    """    
     if value:
         if m := DATE_PATTERN.match(str(value)):
             msec = int(m[1])
             if msec>0:
                 unix_timestamp = msec/1000
-                dt = datetime.fromtimestamp(unix_timestamp)
+                try:
+                    dt = datetime.fromtimestamp(unix_timestamp)
+                except:
+                    dt = None
                 if auto_date:
                     if dt.hour==0 and dt.minute==0 and dt.second==0 and dt.microsecond==0:
                         return date(dt.year, dt.month, dt.day)
@@ -30,12 +40,22 @@ def datetime_from_string(value:str, auto_date:bool=False) -> Union[date,datetime
 
 
 def date_from_string(value:str) -> Union[date,None]:
+    """
+    Dates earlier than 1970 and later than 2038 are breaks the code
+    and not just for the document which has inccorect date entry but also
+    all remaining documents in that search dialog. By returning None we
+    easly identify those currepted documents and inform the owner so they
+    can be fixed.
+    """
     if value:
         if m := DATE_PATTERN.match(str(value)):
             msec = int(m[1])
             if msec>0:
                 unix_timestamp = msec/1000
-                dt = date.fromtimestamp(unix_timestamp)
+                try:
+                    dt = date.fromtimestamp(unix_timestamp)
+                except:
+                    dt = None
                 return dt
             else:
                 return None

--- a/docuware/utils.py
+++ b/docuware/utils.py
@@ -17,6 +17,7 @@ def datetime_from_string(value:str, auto_date:bool=False) -> Union[date,datetime
     all remaining documents in that search dialog. By returning None we
     easly identify those currepted documents and inform the owner so they
     can be fixed.
+    For example: 3023-01-01
     """    
     if value:
         if m := DATE_PATTERN.match(str(value)):
@@ -46,6 +47,7 @@ def date_from_string(value:str) -> Union[date,None]:
     all remaining documents in that search dialog. By returning None we
     easly identify those currepted documents and inform the owner so they
     can be fixed.
+    For example: 3023-01-01
     """
     if value:
         if m := DATE_PATTERN.match(str(value)):


### PR DESCRIPTION
Hi,

We realized  that an inccorect date entries such as "3023-01-01" breaks the code and not just for this specific document but also all the remaining documents in that search dialog. We simply added a try catch statement and returned a None value on error. By doing so we easly identify those currepted documents and inform the owner so those can be fixed. Right now we are using this forked version of your library but we will be glad if you can address this issue so we can keep using the library.

Thank you in advance
Altar