### PR TITLE
Expose document id on SearchResultItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`SearchResultItem.id`**: document id is now exposed directly on search result
+  items, mirroring `Document.id`. Avoids the previous workarounds (walking
+  `item.fields` for `DWDOCID` or parsing `endpoints["self"]`) and removes the
+  need to trigger the lazy `item.document` fetch just to read the id
+
 ## [0.7.10] - 2026-04-07
 
 ### Fixed

--- a/src/docuware/dialogs.py
+++ b/src/docuware/dialogs.py
@@ -349,6 +349,7 @@ class SearchResult:
 class SearchResultItem:
     def __init__(self, config: Dict, result: SearchResult):
         self.result = result
+        self.id = config.get("Id")
         self.fields = [fields.FieldValue.from_config(f) for f in config.get("Fields", [])]
         self.content_type = config.get("ContentType")
         self.title = config.get("Title")

--- a/src/docuware/types.py
+++ b/src/docuware/types.py
@@ -364,6 +364,9 @@ class SearchResultItemP(Protocol):
     def thumbnail(self) -> Tuple[bytes, str, str]: ...
 
     @property
+    def id(self) -> Optional[Any]: ...
+
+    @property
     def title(self) -> Optional[str]: ...
 
     @property

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -31,3 +31,16 @@ def test_search_open_range_lower_bound(dw_search_dialog):
     """Open lower bound: [None, date] must return results, not silently zero."""
     results = dw_search_dialog.search({"DWSTOREDATETIME": [None, date.today()]})
     assert results.count > 0
+
+
+def test_search_result_item_exposes_id(dw_search_dialog):
+    """SearchResultItem.id is populated directly from the search response."""
+    import itertools
+    results = dw_search_dialog.search({"DWSTOREDATETIME": [date(2000, 1, 1), date.today()]})
+    items = list(itertools.islice(results, 3))
+    if not items:
+        import pytest
+        pytest.skip("No documents available to verify id")
+    for item in items:
+        assert item.id is not None
+        assert item.id == item.document.id

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -168,7 +168,8 @@ class TestSearchFlow(unittest.TestCase):
         result_list = list(results)
         self.assertEqual(len(result_list), 1)
         self.assertEqual(result_list[0].title, "Invoice 1")
-        # SearchResultItem doesn't have .id, it has .document.id
+        # SearchResultItem.id mirrors Document.id, available without an extra fetch
+        self.assertEqual(result_list[0].id, "doc1")
         self.assertEqual(result_list[0].document.id, "doc1")
 
 


### PR DESCRIPTION
## Summary

- Adds `SearchResultItem.id`, mirroring `Document.id`, populated from the `Id` field already present in the search response.
- Avoids the previous workarounds (walking `item.fields` for `DWDOCID`, parsing `endpoints["self"]`) and removes the need to trigger the lazy `item.document` fetch just to read the id.
- Updates the `SearchResultItemP` protocol and adds unit + integration coverage.

Closes #15

## Test plan

- [x] Unit tests: `python -m pytest tests/ --ignore=tests/integration` — 337 passed
- [x] Integration tests against live tenant: `DW_TEST_CABINET=Dokumente python -m pytest tests/integration/ -v` — 8 passed (incl. new `test_search_result_item_exposes_id`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)