### PR TITLE
Add TokenStore adapter for refresh-token rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ See [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and [Semantic Versi
 
 ## [Unreleased]
 
+### Added
+
+- **`TokenStore`** abstract base class: adapter interface for loading and
+  persisting OAuth2 token bundles across process restarts. Required for any
+  long-running PKCE-based application — DocuWare rotates refresh tokens on
+  every refresh and revokes the entire token family on reuse (RFC 6749 §10.4),
+  so the rotated tokens must be persisted every time. A concrete
+  `JsonFileTokenStore` reference implementation is shown in
+  `examples/oauth2_login.py`
+- **`connect_with_tokens(token_store=...)`**: opt-in parameter that wires a
+  `TokenStore` into the refresh callback automatically. Loads initial tokens
+  from the store, falls back to explicit `access_token` / `refresh_token`
+  arguments as a bootstrap seed (saved immediately), and persists rotated
+  tokens after every refresh
+- **`atomic_json_write()`**: utility for crash-safe JSON file writes (temp +
+  fsync + chmod + rename), used by both the credentials-file save path and
+  `JsonFileTokenStore`
+
+### Changed
+
+- **Credentials file write** in `connect()` is now atomic via
+  `atomic_json_write()`. A crash mid-write can no longer leave the file
+  half-written
+
 ## [0.7.13] - 2026-05-12
 
 ### Fixed

--- a/examples/oauth2_login.py
+++ b/examples/oauth2_login.py
@@ -56,16 +56,47 @@ Usage:
 from __future__ import annotations
 
 import http.server
+import json
+import pathlib
 import secrets
 import time
 import urllib.parse
 import webbrowser
+from typing import Any, Dict, Optional
 
 import docuware
 
 CALLBACK_PORT = 18923
 CALLBACK_PATH = "/callback"
 REDIRECT_URI = f"http://localhost:{CALLBACK_PORT}{CALLBACK_PATH}"
+
+TOKEN_STORE_PATH = pathlib.Path.home() / ".config" / "docuware-client" / "tokens.json"
+
+
+# ---------------------------------------------------------------------------
+# Reference TokenStore — JSON file with atomic writes
+# ---------------------------------------------------------------------------
+#
+# DocuWare rotates refresh tokens on every refresh and revokes the entire
+# token family if a stale refresh token is reused (RFC 6749 §10.4). The
+# library therefore calls TokenStore.save() after every successful refresh
+# so the next process start sees the rotated bundle. save() MUST be atomic
+# — a half-written file would lose the only valid refresh token and force
+# a full PKCE re-login.
+class JsonFileTokenStore(docuware.TokenStore):
+    """Persist OAuth2 tokens as a JSON file (mode 0o600, atomic writes)."""
+
+    def __init__(self, path: pathlib.Path) -> None:
+        self.path = path
+
+    def load(self) -> Optional[Dict[str, Any]]:
+        if not self.path.exists():
+            return None
+        with open(self.path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def save(self, tokens: Dict[str, Any]) -> None:
+        docuware.atomic_json_write(self.path, tokens, indent=2)
 
 
 # ---------------------------------------------------------------------------
@@ -216,8 +247,11 @@ def main() -> None:
     print(f"  expires_in:    {tokens.get('expires_in')} seconds")
     print()
 
-    # --- Step 7: connect and verify ---
-    print("Connecting to DocuWare with the obtained tokens...")
+    # --- Step 7: persist tokens and connect ---
+    store = JsonFileTokenStore(TOKEN_STORE_PATH)
+    print(f"Persisting tokens to {TOKEN_STORE_PATH}")
+    print("(rotated tokens will be written here automatically on every refresh)")
+    print()
     try:
         client = docuware.connect_with_tokens(
             url=docuware_url,
@@ -225,6 +259,7 @@ def main() -> None:
             refresh_token=tokens.get("refresh_token", ""),
             token_endpoint=endpoints.token_endpoint,
             client_id=client_id,
+            token_store=store,
         )
     except Exception as exc:
         print(f"Connection failed: {exc}")
@@ -238,16 +273,22 @@ def main() -> None:
         for fc in org.file_cabinets:
             print(f"    - {fc.name}")
     print()
-    print("Reusable snippet for your own code:")
+    print("Reusable snippet for subsequent runs (no PKCE login needed):")
     print()
     print("  import docuware")
+    print(f"  store = JsonFileTokenStore({str(TOKEN_STORE_PATH)!r})")
     print("  client = docuware.connect_with_tokens(")
     print(f"      url={docuware_url!r},")
-    print("      access_token=tokens['access_token'],")
-    print("      refresh_token=tokens['refresh_token'],")
     print(f"      token_endpoint={endpoints.token_endpoint!r},")
     print(f"      client_id={client_id!r},")
+    print("      token_store=store,")
     print("  )")
+    print()
+    print("Why a TokenStore is not optional:")
+    print("  DocuWare rotates the refresh token on every refresh and revokes the")
+    print("  entire token family if the previous refresh token is reused (RFC 6749")
+    print("  §10.4). Without persistence, the next process start would fail with")
+    print("  'invalid_grant' and force a fresh PKCE login.")
     print()
 
 

--- a/src/docuware/__init__.py
+++ b/src/docuware/__init__.py
@@ -23,12 +23,14 @@ from docuware.oauth import (
     normalize_docuware_url,
 )
 from docuware.organization import Organization
+from docuware.persistence import TokenStore
 from docuware.textshot import TableZone, TextLine, TextPage, TextShot, TextZone, Word
 from docuware.users import (
     Group,
     User,
 )
 from docuware.utils import (
+    atomic_json_write,
     default_credentials_file,
     quote_value,
     random_password,
@@ -64,11 +66,13 @@ __all__ = [
     "TextShot",
     "TextZone",
     "TokenAuthenticator",
+    "TokenStore",
     "User",
     "UserOrGroupError",
     "Word",
     "DW_OAUTH_SCOPES",
     "OAuthEndpoints",
+    "atomic_json_write",
     "build_authorization_url",
     "connect",
     "connect_with_tokens",

--- a/src/docuware/client.py
+++ b/src/docuware/client.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 from typing import Any, Callable, Dict, Iterator, Optional, Union
 
-from docuware import auth, conn, errors, organization, structs, types
+from docuware import auth, conn, errors, organization, persistence, structs, types, utils
 
 log = logging.getLogger(__name__)
 
@@ -135,10 +135,7 @@ def connect(
 
         if file_creds != new_creds:
             try:
-                credentials_file.parent.mkdir(exist_ok=True, parents=True)
-                with open(credentials_file, "w", encoding="utf-8") as f:
-                    json.dump(new_creds, f, indent=4)
-                os.chmod(credentials_file, 0o600)
+                utils.atomic_json_write(credentials_file, new_creds, indent=4)
             except OSError as exc:
                 log.warning("Failed to save credentials to %s: %s", credentials_file, exc)
 
@@ -147,12 +144,13 @@ def connect(
 
 def connect_with_tokens(
     url: str,
-    access_token: str,
-    refresh_token: str,
-    token_endpoint: str,
-    client_id: str,
+    access_token: str = "",
+    refresh_token: str = "",
+    token_endpoint: str = "",
+    client_id: str = "",
     *,
     client_secret: str = "",
+    token_store: Optional[persistence.TokenStore] = None,
     on_token_refresh: Optional[Callable[[Dict[str, Any]], None]] = None,
     verify_certificate: bool = True,
     timeout: Optional[float] = None,
@@ -166,16 +164,31 @@ def connect_with_tokens(
     Note: this function does *not* call :func:`~docuware.oauth.discover_oauth_endpoints`
     — the caller must resolve the token_endpoint beforehand.
 
+    DocuWare rotates refresh tokens (RFC 6749 §10.4) and revokes the entire
+    token family on reuse. Production callers should pass a ``token_store``
+    so the rotated tokens are persisted across process restarts; otherwise
+    the next start will fail with ``invalid_grant`` and force a fresh PKCE
+    login.
+
     Args:
         url:              DocuWare Platform base URL.
-        access_token:     OAuth2 access token.
-        refresh_token:    OAuth2 refresh token.
+        access_token:     OAuth2 access token. Optional when ``token_store``
+                          already contains tokens; required otherwise.
+        refresh_token:    OAuth2 refresh token. Optional when ``token_store``
+                          already contains tokens; required otherwise.
         token_endpoint:   Token endpoint URL (from OpenID Connect discovery).
         client_id:        OAuth2 client ID.
         client_secret:    OAuth2 client secret — required for confidential clients
                           (web apps), empty for public/native clients (default).
+        token_store:      Optional :class:`~docuware.TokenStore` adapter.  If
+                          set, ``load()`` is consulted for the initial tokens
+                          (falling back to the explicit ``access_token`` /
+                          ``refresh_token`` arguments as a bootstrap seed),
+                          and ``save()`` is wired in as the rotation callback.
+                          Mutually exclusive with ``on_token_refresh``.
         on_token_refresh: Optional callback(tokens: dict) called after each
                           successful token refresh — use it to persist new tokens.
+                          Mutually exclusive with ``token_store``.
         verify_certificate: Whether to verify TLS certificates (default True).
         timeout:          Request timeout in seconds.  Defaults to the value of
                           the ``DW_TIMEOUT`` environment variable, or 30 s if not set.
@@ -183,6 +196,48 @@ def connect_with_tokens(
     Returns:
         Connected DocuwareClient instance.
     """
+    if token_store is not None:
+        if on_token_refresh is not None:
+            raise ValueError(
+                "token_store and on_token_refresh are mutually exclusive — "
+                "the store's save() is used as the refresh callback"
+            )
+        bundle = token_store.load()
+        if bundle:
+            stored_access = bundle.get("access_token", "")
+            stored_refresh = bundle.get("refresh_token", "")
+            if not (stored_access and stored_refresh):
+                raise errors.AccountError(
+                    "token_store returned an incomplete bundle "
+                    "(missing access_token or refresh_token)"
+                )
+            if (access_token and access_token != stored_access) or (
+                refresh_token and refresh_token != stored_refresh
+            ):
+                log.info(
+                    "token_store contains tokens; ignoring explicit access_token/refresh_token"
+                )
+            access_token = stored_access
+            refresh_token = stored_refresh
+        elif access_token and refresh_token:
+            # Bootstrap: seed the empty store with the supplied tokens so a
+            # crash before the first refresh does not lose them.
+            token_store.save({"access_token": access_token, "refresh_token": refresh_token})
+        else:
+            raise errors.AccountError(
+                "token_store is empty and no explicit access_token/refresh_token "
+                "given — run the PKCE login first to seed the store"
+            )
+        on_token_refresh = token_store.save
+
+    if not access_token or not refresh_token:
+        raise errors.AccountError(
+            "access_token and refresh_token are required "
+            "(or supply a populated token_store)"
+        )
+    if not token_endpoint or not client_id:
+        raise errors.AccountError("token_endpoint and client_id are required")
+
     authenticator = auth.TokenAuthenticator(
         access_token=access_token,
         refresh_token=refresh_token,

--- a/src/docuware/persistence.py
+++ b/src/docuware/persistence.py
@@ -1,0 +1,54 @@
+"""Persistence adapters for OAuth2 token bundles.
+
+DocuWare's IdentityServer issues *rotating* refresh tokens with reuse
+detection (RFC 6749 §10.4): every successful refresh response invalidates
+the prior refresh token, and reuse of the prior token revokes the entire
+token family. Clients that want to survive a process restart must
+therefore persist the rotated tokens *every* time a refresh succeeds —
+not only at first login.
+
+:class:`TokenStore` is the adapter interface the library uses to do that
+without taking a position on *where* tokens live (file, keyring, secrets
+manager, database row, ...). Users supply a concrete implementation; the
+library calls it at the right moments via
+:func:`docuware.connect_with_tokens`.
+
+A reference :class:`TokenStore` implementation backed by a JSON file is
+shown in ``examples/oauth2_login.py``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class TokenStore(ABC):
+    """Adapter for loading and persisting an OAuth2 token bundle.
+
+    Implementations decide *where* tokens live. The library is responsible
+    for *when* to call :meth:`save` — exactly once per successful refresh,
+    so that the next process start sees the rotated refresh token.
+
+    Implementations MUST persist atomically (e.g. write-temp + rename) so
+    a crash mid-write cannot leave the store with no usable refresh token.
+    See :func:`docuware.atomic_json_write` for a primitive that does this.
+    """
+
+    @abstractmethod
+    def load(self) -> Optional[Dict[str, Any]]:
+        """Return the stored token bundle, or ``None`` if nothing stored.
+
+        Expected keys: ``access_token``, ``refresh_token``. Implementations
+        may store additional fields (e.g. ``expires_at``, ``scope``); the
+        library passes them through unchanged.
+        """
+
+    @abstractmethod
+    def save(self, tokens: Dict[str, Any]) -> None:
+        """Persist the given token bundle.
+
+        Called after every successful refresh, and once initially in the
+        bootstrap path when an empty store is seeded with explicit tokens.
+        MUST be atomic.
+        """

--- a/src/docuware/utils.py
+++ b/src/docuware/utils.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import secrets
 import re
+import tempfile
 from datetime import date, datetime
 from typing import Any, Optional, Union
 
@@ -148,6 +150,43 @@ def write_binary_file(blob: bytes, path: Union[str, pathlib.Path]) -> pathlib.Pa
     with open(path, "wb") as f:
         f.write(blob)
     return path
+
+
+def atomic_json_write(
+    path: Union[str, pathlib.Path],
+    data: Any,
+    *,
+    mode: int = 0o600,
+    indent: Optional[int] = None,
+) -> None:
+    """Write ``data`` as JSON to ``path`` atomically.
+
+    Writes to a temporary file in the same directory, fsyncs, ``chmod``s
+    to ``mode`` (default 0o600 — sensitive material), then ``os.replace``s
+    over the destination. A crash mid-write therefore cannot leave a
+    half-written file at ``path``; the previous content remains intact.
+
+    The parent directory is created if it does not exist.
+    """
+    path = pathlib.Path(path)
+    path.parent.mkdir(exist_ok=True, parents=True)
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=indent)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def random_password(length: int = 16) -> str:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from docuware import DocuwareClient, errors
+from docuware import DocuwareClient, TokenStore, errors
 from docuware.client import connect, connect_with_tokens
 from docuware.auth import TokenAuthenticator
 
@@ -186,3 +186,125 @@ def test_connect_with_tokens_passes_callback():
             on_token_refresh=callback,
         )
     assert client.conn.authenticator.on_token_refresh is callback
+
+
+# --- connect_with_tokens() with TokenStore ---
+
+
+class _MemoryTokenStore(TokenStore):
+    """In-memory TokenStore for tests; records every save() call."""
+
+    def __init__(self, initial=None):
+        self._bundle = initial
+        self.saves: list = []
+
+    def load(self):
+        return self._bundle
+
+    def save(self, tokens):
+        self._bundle = dict(tokens)
+        self.saves.append(dict(tokens))
+
+
+def test_connect_with_tokens_uses_store_tokens():
+    store = _MemoryTokenStore({"access_token": "from_store", "refresh_token": "rt_store"})
+    with patch("docuware.client.DocuwareClient.__init__", _patched_init(_token_handler())):
+        client = connect_with_tokens(
+            url=BASE_URL,
+            token_endpoint="https://login.example.com/token",
+            client_id="test-client",
+            token_store=store,
+        )
+    assert client.conn.session.auth.token == "from_store"
+    assert client.conn.authenticator.refresh_token == "rt_store"
+    # Bound-method identity is unstable in Python; compare by underlying function + instance.
+    cb = client.conn.authenticator.on_token_refresh
+    assert cb.__self__ is store and cb.__func__ is _MemoryTokenStore.save
+    assert store.saves == []  # store already populated, no bootstrap save
+
+
+def test_connect_with_tokens_bootstrap_seeds_empty_store():
+    store = _MemoryTokenStore()  # empty
+    with patch("docuware.client.DocuwareClient.__init__", _patched_init(_token_handler())):
+        connect_with_tokens(
+            url=BASE_URL,
+            access_token="at_seed",
+            refresh_token="rt_seed",
+            token_endpoint="https://login.example.com/token",
+            client_id="test-client",
+            token_store=store,
+        )
+    assert len(store.saves) == 1
+    assert store.saves[0] == {"access_token": "at_seed", "refresh_token": "rt_seed"}
+
+
+def test_connect_with_tokens_empty_store_without_seed_raises():
+    store = _MemoryTokenStore()  # empty
+    with pytest.raises(errors.AccountError, match="token_store is empty"):
+        connect_with_tokens(
+            url=BASE_URL,
+            token_endpoint="https://login.example.com/token",
+            client_id="test-client",
+            token_store=store,
+        )
+
+
+def test_connect_with_tokens_store_and_callback_mutually_exclusive():
+    store = _MemoryTokenStore({"access_token": "a", "refresh_token": "r"})
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        connect_with_tokens(
+            url=BASE_URL,
+            token_endpoint="https://login.example.com/token",
+            client_id="test-client",
+            token_store=store,
+            on_token_refresh=lambda t: None,
+        )
+
+
+def test_connect_with_tokens_incomplete_store_bundle_raises():
+    store = _MemoryTokenStore({"access_token": "a"})  # no refresh_token
+    with pytest.raises(errors.AccountError, match="incomplete bundle"):
+        connect_with_tokens(
+            url=BASE_URL,
+            token_endpoint="https://login.example.com/token",
+            client_id="test-client",
+            token_store=store,
+        )
+
+
+def test_connect_with_tokens_refresh_triggers_store_save():
+    """End-to-end: refresh → save() chain populates the store with rotated tokens."""
+    store = _MemoryTokenStore({"access_token": "old_at", "refresh_token": "old_rt"})
+
+    with patch("docuware.client.DocuwareClient.__init__", _patched_init(_token_handler())):
+        client = connect_with_tokens(
+            url=BASE_URL,
+            token_endpoint="https://login.example.com/token",
+            client_id="test-client",
+            token_store=store,
+        )
+
+    # TokenAuthenticator.authenticate() makes a one-shot httpx.post that does
+    # not go through the patched session — patch the call directly.
+    refresh_response = MagicMock()
+    refresh_response.json.return_value = {
+        "access_token": "new_at",
+        "refresh_token": "new_rt",
+        "expires_in": 3600,
+    }
+    refresh_response.raise_for_status.return_value = None
+    with patch("docuware.auth.httpx.post", return_value=refresh_response) as mock_post:
+        client.conn.authenticator.authenticate(client.conn)
+
+    mock_post.assert_called_once()
+    assert client.conn.authenticator.access_token == "new_at"
+    assert client.conn.authenticator.refresh_token == "new_rt"
+    assert len(store.saves) == 1
+    assert store.saves[0]["access_token"] == "new_at"
+    assert store.saves[0]["refresh_token"] == "new_rt"
+
+
+def test_token_store_is_abstract():
+    """TokenStore cannot be instantiated without overriding load/save."""
+    with pytest.raises(TypeError):
+        TokenStore()  # type: ignore[abstract]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 
 from docuware.errors import DataError, InternalError
 from docuware.utils import (
+    atomic_json_write,
     date_from_string,
     date_to_string,
     datetime_from_string,
@@ -254,3 +255,67 @@ def test_random_password_valid_chars():
     allowed = set("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.,;:-_/+=")
     pw = random_password(200)
     assert all(c in allowed for c in pw)
+
+
+# --- atomic_json_write() ---
+
+def test_atomic_json_write_creates_file(tmp_path):
+    import json
+    path = tmp_path / "out.json"
+    atomic_json_write(path, {"a": 1, "b": [2, 3]})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"a": 1, "b": [2, 3]}
+
+
+def test_atomic_json_write_creates_parent_dir(tmp_path):
+    path = tmp_path / "nested" / "dir" / "out.json"
+    atomic_json_write(path, {"x": 1})
+    assert path.exists()
+
+
+def test_atomic_json_write_default_mode_is_0o600(tmp_path):
+    import os
+    path = tmp_path / "out.json"
+    atomic_json_write(path, {"k": "v"})
+    mode = os.stat(path).st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_atomic_json_write_custom_mode(tmp_path):
+    import os
+    path = tmp_path / "out.json"
+    atomic_json_write(path, {"k": "v"}, mode=0o644)
+    mode = os.stat(path).st_mode & 0o777
+    assert mode == 0o644
+
+
+def test_atomic_json_write_overwrites_existing(tmp_path):
+    import json
+    path = tmp_path / "out.json"
+    path.write_text('{"old": true}', encoding="utf-8")
+    atomic_json_write(path, {"new": True})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"new": True}
+
+
+def test_atomic_json_write_failure_leaves_destination_intact(tmp_path):
+    import json
+    path = tmp_path / "out.json"
+    path.write_text('{"old": true}', encoding="utf-8")
+
+    class _Unserializable:
+        pass
+
+    with pytest.raises(TypeError):
+        atomic_json_write(path, {"bad": _Unserializable()})
+
+    # Original content is still there; no half-written file
+    assert json.loads(path.read_text(encoding="utf-8")) == {"old": True}
+    # No temp file lingering
+    leftovers = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert leftovers == []
+
+
+def test_atomic_json_write_indent(tmp_path):
+    path = tmp_path / "out.json"
+    atomic_json_write(path, {"a": 1}, indent=2)
+    text = path.read_text(encoding="utf-8")
+    assert "\n" in text  # indented output spans multiple lines


### PR DESCRIPTION
## Summary

Adds a `TokenStore` adapter interface so callers don't have to reinvent atomic refresh-token persistence themselves.

DocuWare's IdentityServer rotates refresh tokens (RFC 6749 §10.4): every refresh response invalidates the prior refresh token, and reuse of the prior token revokes the entire token family — forcing a full PKCE re-login on the next process start. The runtime side was already correct (`TokenAuthenticator.on_token_refresh` fires the callback with the rotated bundle), but the persistence half was left to consumers — every consumer ends up writing the same atomic-write boilerplate.

### Library

- New `TokenStore` ABC in `docuware/persistence.py` with `load()` / `save()`. No concrete implementation lives in the library — storage choice (file, keyring, secrets manager, …) is left to the caller.
- `connect_with_tokens(token_store=...)` accepts a store. Soft-bootstrap semantics:
  - If the store has tokens, they win (explicit `access_token` / `refresh_token` args are ignored, with a log message).
  - If the store is empty but explicit tokens are given, they seed the store (saved immediately so a crash before the first refresh does not lose them).
  - If the store is empty and no explicit tokens are given, it raises.
- Mutually exclusive with `on_token_refresh` — passing both raises `ValueError`.
- New `atomic_json_write()` utility (`docuware/utils.py`): temp + fsync + chmod + `os.replace`.

### Bundled fix

`connect()`'s credentials-file write was non-atomic (`open(file, "w")` direct). Now uses `atomic_json_write()` too. This is technically out of scope for #17 but uses the same primitive, so it lands here rather than in a separate PR.

### Example

`examples/oauth2_login.py` now demonstrates a `JsonFileTokenStore` reference implementation (~15 lines) and explains why a TokenStore is not optional for long-running PKCE applications.

### Tests

- 351 unit tests + 8 integration tests, all passing.
- New coverage: `atomic_json_write` (mode, parent dir creation, failure path, indent), `TokenStore` is abstract, four `connect_with_tokens(token_store=...)` paths (populated, bootstrap, empty + no seed, mutual exclusivity), and an end-to-end refresh → save() chain.

Closes #17

## Note for the reviewer

@haraldschilly — since the OAuth2 path is largely your work and I don't have a PKCE test harness on my side, I'd particularly appreciate it if you could test this against your real DocuWare deployment before merging:

- Run `examples/oauth2_login.py` and verify a `tokens.json` lands at the expected path with mode 0o600.
- Restart the example, verify it reuses the persisted tokens (no second browser PKCE flow needed).
- Let it sit until at least one access-token expiry has passed, then trigger any operation and verify the rotated tokens were written back to `tokens.json`.

Happy to revise the API shape or naming if any of it doesn't feel right — particularly the soft-bootstrap behavior, which deviates slightly from your original "mutually exclusive" proposal.

## Test plan

- [x] Unit tests: `python -m pytest tests/ --ignore=tests/integration` — 351 passed
- [x] Integration tests: `DW_TEST_CABINET=Dokumente python -m pytest tests/integration/ -v` — 8 passed
- [ ] Manual end-to-end PKCE test against a real DocuWare instance (rotation + persistence) — pending @haraldschilly review

🤖 Generated with [Claude Code](https://claude.com/claude-code)